### PR TITLE
Redwine:

### DIFF
--- a/editlink.php
+++ b/editlink.php
@@ -101,8 +101,8 @@ if ($link) {
 						if ($linkres->category != sanitize($_POST["category"], 3)){
 							$body = $body . $main_smarty->get_config_vars('PLIKLI_Visual_Submit2_Category') . " change\r\n\r\n" . $main_smarty->get_config_vars('PLIKLI_Visual_EditStory_Email_PreviousText') . ": " . GetCatName($linkres->category) . "\r\n\r\n" . $main_smarty->get_config_vars('PLIKLI_Visual_EditStory_Email_NewText') . ": " . GetCatName(sanitize($_POST["category"], 3)) . "\r\n\r\n";
 						}
-						if ($linkres->title != sanitize($_POST["title"], 4, $Story_Content_Tags_To_Allow)){
-							$body = $body . $main_smarty->get_config_vars('PLIKLI_Visual_Submit2_Title') . " change\r\n\r\n" . $main_smarty->get_config_vars('PLIKLI_Visual_EditStory_Email_PreviousText') . ": " . $linkres->title . "\r\n\r\n" . $main_smarty->get_config_vars('PLIKLI_Visual_EditStory_Email_NewText') . ": " . sanitize($_POST["title"], 3) . "\r\n\r\n";
+						if ($linkres->title != sanitize(trim($_POST["title"]), 4, $Story_Content_Tags_To_Allow)){
+							$body = $body . $main_smarty->get_config_vars('PLIKLI_Visual_Submit2_Title') . " change\r\n\r\n" . $main_smarty->get_config_vars('PLIKLI_Visual_EditStory_Email_PreviousText') . ": " . $linkres->title . "\r\n\r\n" . $main_smarty->get_config_vars('PLIKLI_Visual_EditStory_Email_NewText') . ": " . sanitize(trim($_POST["title"]), 3) . "\r\n\r\n";
 						}      
 					
 						if ($linkres->content != close_tags(sanitize($_POST["bodytext"], 4, $Story_Content_Tags_To_Allow))) {
@@ -145,8 +145,8 @@ if ($link) {
 				}else{
 					$linkres->category=sanitize($_POST['category'], 3);
 			}
-			if($linkres->title != stripslashes(sanitize($_POST['title'], 3))){
-				$linkres->title = stripslashes(sanitize($_POST['title'], 3));
+			if($linkres->title != stripslashes(sanitize(trim($_POST['title']), 3))){
+				$linkres->title = stripslashes(sanitize(trim($_POST['title']), 3));
 				$linkres->title_url = makeUrlFriendly($linkres->title, $linkres->id);
 			}
 			

--- a/libs/link.php
+++ b/libs/link.php
@@ -214,7 +214,7 @@ class Link {
 		$link_title = $db->escape($this->title);
 		$link_title_url = $db->escape($this->title_url);
 		if($link_title_url == ""){$link_title_url = makeUrlFriendly($this->title, $this->id);}
-		$link_tags = $db->escape($this->tags);
+		$link_tags = preg_replace('/[^\p{L}\p{N}_\s\,]/u', '', $this->tags); //$db->escape($this->tags);
 		$link_content = $db->escape($this->content);
 		$link_field1 = $db->escape($this->link_field1);
 		$link_field2 = $db->escape($this->link_field2);

--- a/submit.php
+++ b/submit.php
@@ -167,9 +167,10 @@ function do_submit1() {
 	{
 	    $linkres->get($url);
 	    if (isset($_POST['title']) && !empty($_POST['title']))
-	    	$linkres->title = $db->escape(stripslashes(sanitize($_POST['title'], 4, $Story_Content_Tags_To_Allow)));
+	    	$linkres->title = $db->escape(stripslashes(sanitize(trim($_POST['title']), 4, $Story_Content_Tags_To_Allow)));
 	    if (isset($_POST['tags']) && !empty($_POST['tags']))
 	    	$linkres->tags = stripslashes(sanitize($_POST['tags'], 4));
+			$linkres->tags = preg_replace('/[^\p{L}\p{N}_\s\,]/u', '', $linkres->tags);
 	    if (isset($_POST['description']) && !empty($_POST['description']))
 	    	$linkres->content = stripslashes(sanitize($_POST['description'], 4, $Story_Content_Tags_To_Allow));
 
@@ -395,7 +396,7 @@ function do_submit2() {
 	$thecat = get_cached_category_data('category_id', $linkres->category);
 	$main_smarty->assign('request_category_name', $thecat->category_name);
 
-	$linkres->title = stripslashes(sanitize($_POST['title'], 3));
+	$linkres->title = stripslashes(sanitize(trim($_POST['title']), 3));
 	$linkres->title_url = makeUrlFriendly($linkres->title, $linkres->id);
 	$linkres->tags = tags_normalize_string(stripslashes(sanitize($_POST['tags'], 3)));
 	$linkres->content = close_tags(stripslashes(sanitize($_POST['bodytext'], 4, $Story_Content_Tags_To_Allow)));


### PR DESCRIPTION
1- Upon submitting and editing stories, tags fields are stripped from any character that is not alphanumeric, underscore, hyphen and comma. However, I noticed that RSS import tags with an apostrophe which is causing an error in the query. I applied more filtering to remove the apostrophe because it is also removed in the search.

2- Fixed a minor issue that is not causing any problem, caught by John on the Plikli forum. title are not trimmed and a space at the end of the tilte was replaced by a hyphen.